### PR TITLE
Enhance chat responses and interactive controls

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -503,6 +503,17 @@ button[title*="sidebar"] svg,
     background: linear-gradient(180deg, var(--secondary-color), var(--secondary-dark));
 }
 
+.follow-up-card {
+    background: rgba(103, 126, 217, 0.08);
+    border: 1px solid rgba(103, 126, 217, 0.2);
+    border-radius: 14px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    box-shadow: 0 12px 30px -15px rgba(39, 37, 87, 0.35);
+    color: var(--secondary-dark);
+    font-weight: 500;
+}
+
 .avatar-container {
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- render chat messages with basic markdown formatting and simulate a more natural typing animation
- add a follow-up prompt with reset control after assistant responses and persist related session state
- toggle the help and export controls from the top action bar and style the follow-up prompt card

## Testing
- python -m compileall Magnus

------
https://chatgpt.com/codex/tasks/task_e_68e6119343608332a8882c6e58818d26