### PR TITLE
Refine chat follow-up flow and auto-scrolling

### DIFF
--- a/app.py
+++ b/app.py
@@ -843,14 +843,14 @@ This ensures your idea gets to the right people and gets proper consideration.""
         ):
             st.markdown("""
             <div class="follow-up-card">
-                <strong>Need anything else?</strong><br>
-                Ask a follow-up question in the box below or reset the chat to start fresh.
+                <strong>Has this answered your question?</strong><br>
+                You can ask a follow-up below or reset the chat to start again.
             </div>
             """, unsafe_allow_html=True)
 
             follow_col1, follow_col2 = st.columns([3, 1])
             with follow_col1:
-                st.caption("I'm ready for another question whenever you are.")
+                st.caption("Type another question in the chat box to keep the conversation going.")
             with follow_col2:
                 if st.button("🔄 Reset chat", use_container_width=True, key="followup_reset"):
                     reset_chat()

--- a/app.py
+++ b/app.py
@@ -863,11 +863,16 @@ This ensures your idea gets to the right people and gets proper consideration.""
             """
             <script>
             const parentWindow = window.parent;
-            if (parentWindow && parentWindow.document && parentWindow.document.body) {
-                parentWindow.scrollTo({
-                    top: parentWindow.document.body.scrollHeight,
-                    behavior: 'smooth'
-                });
+            if (parentWindow && parentWindow.document) {
+                const anchor = parentWindow.document.getElementById('chat-bottom-anchor');
+                if (anchor && anchor.scrollIntoView) {
+                    anchor.scrollIntoView({ behavior: 'smooth', block: 'end' });
+                } else if (parentWindow.document.body) {
+                    parentWindow.scrollTo({
+                        top: parentWindow.document.body.scrollHeight,
+                        behavior: 'smooth'
+                    });
+                }
             }
             </script>
             """,

--- a/app.py
+++ b/app.py
@@ -823,8 +823,13 @@ This ensures your idea gets to the right people and gets proper consideration.""
                             response = get_assistant_response(client, thread_id)
                             if response:
                                 loading_container.empty()
-                                typing_effect_with_avatar(response, "assistant")
-                                append_message("assistant", response)
+                                follow_up_line = (
+                                    "Has this answered your question? You can ask a follow-up below "
+                                    "or reset the chat if you need to start again."
+                                )
+                                enhanced_response = f"{response.strip()}\n\n{follow_up_line}"
+                                typing_effect_with_avatar(enhanced_response, "assistant")
+                                append_message("assistant", enhanced_response)
                                 st.session_state.follow_up_prompt = True
                             else:
                                 loading_container.markdown("❌ Could not retrieve assistant response.")
@@ -838,14 +843,14 @@ This ensures your idea gets to the right people and gets proper consideration.""
         ):
             st.markdown("""
             <div class="follow-up-card">
-                <strong>Has this answered your question?</strong><br>
-                You can ask a follow-up below or reset the chat to start again.
+                <strong>Need anything else?</strong><br>
+                Ask a follow-up question in the box below or reset the chat to start fresh.
             </div>
             """, unsafe_allow_html=True)
 
             follow_col1, follow_col2 = st.columns([3, 1])
             with follow_col1:
-                st.caption("Type another question in the chat box to keep the conversation going.")
+                st.caption("I'm ready for another question whenever you are.")
             with follow_col2:
                 if st.button("🔄 Reset chat", use_container_width=True, key="followup_reset"):
                     reset_chat()
@@ -857,9 +862,12 @@ This ensures your idea gets to the right people and gets proper consideration.""
         html(
             """
             <script>
-            const anchor = window.parent.document.querySelector('#chat-bottom-anchor');
-            if (anchor) {
-                anchor.scrollIntoView({ behavior: 'smooth', block: 'end' });
+            const parentWindow = window.parent;
+            if (parentWindow && parentWindow.document && parentWindow.document.body) {
+                parentWindow.scrollTo({
+                    top: parentWindow.document.body.scrollHeight,
+                    behavior: 'smooth'
+                });
             }
             </script>
             """,

--- a/styles.css
+++ b/styles.css
@@ -503,6 +503,17 @@ button[title*="sidebar"] svg,
     background: linear-gradient(180deg, var(--secondary-color), var(--secondary-dark));
 }
 
+.follow-up-card {
+    background: rgba(103, 126, 217, 0.08);
+    border: 1px solid rgba(103, 126, 217, 0.2);
+    border-radius: 14px;
+    padding: 1rem 1.25rem;
+    margin: 1rem 0;
+    box-shadow: 0 12px 30px -15px rgba(39, 37, 87, 0.35);
+    color: var(--secondary-dark);
+    font-weight: 500;
+}
+
 .avatar-container {
     display: flex;
     justify-content: flex-start;


### PR DESCRIPTION
## Summary
- centralize message logging to trigger scrolling and remove bold markdown artifacts from option confirmations
- surface the follow-up prompt immediately after AI replies with a reset action and smoother call to action
- add an auto-scroll anchor so the chat input stays with the latest exchange during the conversation

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e6119343608332a8882c6e58818d26